### PR TITLE
Update pom.xml: replace jBCrypt with spring-security-crypto (BCryptPasswordEncoder)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -113,11 +113,11 @@
       <version>20231013</version>
     </dependency>
 
-    <!-- BCrypt -->
+  <!-- BCrypt password encoder (Spring Security) -->
     <dependency>
-      <groupId>org.mindrot</groupId>
-      <artifactId>jbcrypt</artifactId>
-      <version>0.4</version>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-crypto</artifactId>
+      <version>6.2.1</version>
     </dependency>
 
   </dependencies>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -117,7 +117,14 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-crypto</artifactId>
-      <version>6.2.1</version>
+      <version>6.4.4</version>
+    </dependency>
+
+    <!-- Required by spring-security-crypto for logging -->
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
     </dependency>
 
   </dependencies>

--- a/backend/src/main/java/it/unicas/action/LoginAction.java
+++ b/backend/src/main/java/it/unicas/action/LoginAction.java
@@ -6,7 +6,7 @@ import it.unicas.dbutil.DBUtil;
 import it.unicas.dto.UserAuthDTO;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.sql.Connection;
 import java.sql.Timestamp;
@@ -69,7 +69,8 @@ public class LoginAction extends ActionSupport {
                 return SUCCESS;
             }
 
-            if (BCrypt.checkpw(password, userAuth.getPasswordHash())) {
+            BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+            if (encoder.matches(password, userAuth.getPasswordHash())) {
                 success = true;
                 message = "Login successful!";
                 username = userAuth.getUsername();

--- a/backend/src/main/java/it/unicas/action/RegistrationAction.java
+++ b/backend/src/main/java/it/unicas/action/RegistrationAction.java
@@ -8,7 +8,7 @@ import it.unicas.dto.UserDTO;
 import it.unicas.dto.UserAuthDTO;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.sql.*;
 import java.text.SimpleDateFormat;
@@ -56,7 +56,8 @@ public class RegistrationAction extends ActionSupport {
 
         UserAuthDTO authDTO = new UserAuthDTO();
         authDTO.setEmail(email);
-        authDTO.setPasswordHash(BCrypt.hashpw(password, BCrypt.gensalt()));
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        authDTO.setPasswordHash(encoder.encode(password));
         authDTO.setUsername(name + " " + surname);
         authDTO.setCreatedAt(now);
         authDTO.setUpdatedAt(now);


### PR DESCRIPTION
This pull request updates the `pom.xml` to replace the legacy `org.mindrot.jbcrypt` dependency with the more modern and actively maintained `spring-security-crypto` (version 6.4.4).

Changes:
- Removed `org.mindrot.jbcrypt`
- Added `org.springframework.security:spring-security-crypto`
- Added `commons-logging:1.2` (required by Spring for internal logging)

This improves security and ensures better compatibility with current Java environments.
The project now uses `BCryptPasswordEncoder` for password hashing.

No other functionality was changed.
